### PR TITLE
Remove unsupported option from PHP Dockerfile

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -40,7 +40,7 @@ RUN extBuildDeps=" \
             libzip-dev \
             sendmail && \
     rm -rf /var/lib/apt/lists/* && \
-    docker-php-ext-configure gd --enable-gd-native-ttf --with-jpeg-dir=/usr/lib/x86_64-linux-gnu --with-png-dir=/usr/lib/x86_64-linux-gnu --with-freetype-dir=/usr/lib/x86_64-linux-gnu && \
+    docker-php-ext-configure gd --with-jpeg-dir=/usr/lib/x86_64-linux-gnu --with-png-dir=/usr/lib/x86_64-linux-gnu --with-freetype-dir=/usr/lib/x86_64-linux-gnu && \
     docker-php-ext-configure intl --enable-intl && \
     docker-php-ext-install \
             exif \


### PR DESCRIPTION
Currently, building the `php` docker image fails:

```
configure: error: unrecognized options: --enable-gd-native-ttf
ERROR: Service 'php' failed to build: The command [...] returned a non-zero code: 1
```

According to the [PHP manual](https://www.php.net/manual/en/image.installation.php) that flag has been "removed as of PHP 7.2.0". Removing it from the `Dockerfile` allowed me to build the Docker image without further errors.